### PR TITLE
Revert "Bump python from 3.10-buster to 3.11-buster in /examples/rrsa/python3-sdk"

### DIFF
--- a/examples/rrsa/python3-sdk/Dockerfile
+++ b/examples/rrsa/python3-sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster
+FROM python:3.10-buster
 # TARGETPLATFORM
 
 WORKDIR /app


### PR DESCRIPTION
Reverts AliyunContainerService/ack-ram-tool#142