### PR TITLE
Revert "Bump charset-normalizer from 2.1.1 to 3.0.1 in /examples/rrsa/python3-sdk"

### DIFF
--- a/examples/rrsa/python3-sdk/requirements.txt
+++ b/examples/rrsa/python3-sdk/requirements.txt
@@ -15,7 +15,7 @@ async-timeout==4.0.2
 attrs==22.2.0
 certifi==2022.9.24
 cffi==1.15.1
-charset-normalizer==3.0.1
+charset-normalizer==2.1.1
 crcmod==1.7
 cryptography==39.0.1
 frozenlist==1.3.1


### PR DESCRIPTION
Reverts AliyunContainerService/ack-ram-tool#153